### PR TITLE
Ignore changes for scaling operations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -180,6 +180,15 @@ resource "aws_elasticache_replication_group" "default" {
   depends_on = [
     aws_elasticache_parameter_group.default
   ]
+
+  lifecycle {
+    ignore_changes = [
+      num_node_groups,
+      replicas_per_node_group,
+      node_type,
+    ]
+  }
+
 }
 
 #


### PR DESCRIPTION
# Jira
https://getflex.atlassian.net/browse/INFRA-2352

# Summary
Forked the Cloudposse module for ElastiCache Redis. Modified it to ignore changes to attributes that may be affected by scaling operations. If we perform scaling operations outside of Terraform (like we do with RDS) then it'll be annoying to try to keep the IaC in sync.  